### PR TITLE
Enable maven cache

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,6 +61,7 @@ jobs:
       with:
         distribution: 'corretto'
         java-version: '21'
+        cache: 'maven'
 
     - name: "Mapped deployment"
       id: mapper


### PR DESCRIPTION
Since we now have this separate workflow for java21 products then I think enabling maven cache is trivial and seems worth doing.