### PR TITLE
feat: Shared publish gem workflow

### DIFF
--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -1,0 +1,56 @@
+name: Release and Publish Gem
+
+on:
+  workflow_call:
+    secrets:
+      github_token:
+        description: GitHub token with packages:write permission
+        required: true
+
+jobs:
+  build:
+    name: Build gem package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Record desired ruby version
+        id: ruby
+        shell: bash
+        run: |
+          [ -f .ruby-version ] && echo version=$(cat .ruby-version) | tee -a $GITHUB_OUTPUT || echo "version=" >> $GITHUB_OUTPUT
+
+      - name: Setup ruby
+        if: steps.ruby.outputs.version != ''
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ steps.ruby.outputs.version }}
+
+      - name: Git information
+        id: gitinfo
+        run: |
+          make tags | tee -a $GITHUB_OUTPUT
+
+      - name: Build gem
+        run: make gem
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+        with:
+          tag_name: ${{ steps.gitinfo.outputs.version }}
+          name: v${{ steps.gitinfo.outputs.version }}
+          generate_release_notes: true
+          draft: false
+          prerelease: false
+          files: |
+            ${{ steps.gitinfo.outputs.name }}-${{ steps.gitinfo.outputs.version }}.gem
+
+      - name: Publish gem
+        env:
+          PAT: ${{ secrets.github_token }}
+        run: make publish


### PR DESCRIPTION
Introduces a reusable GitHub Actions workflow to automate the process of building, releasing, and publishing Ruby gems, standardising the release pipeline for projects.

## What's changed:
- A new GitHub Actions workflow for releasing and publishing gems was added.
- Automated detection of the project's specified Ruby version for consistent builds was implemented.
- The gem build process was integrated into the automated pipeline.
- GitHub releases are now automatically created, including generated release notes and the gem artefact.
- The built gem is automatically published to a package registry following a successful release.